### PR TITLE
reduce compilation bloat on test feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,4 +29,4 @@ tokio = { version = "1", features = [ "rt-multi-thread", "macros" ] }
 [features]
 default = []
 cli = [ "structopt" ]
-test = [ "drop/test", "lazy_static", "tokio/rt-multi-thread" ]
+test = [ "drop/test", "lazy_static" ]


### PR DESCRIPTION
This removes the requirement for the macros and rt-multi-thread features of tokio when building the test features. 

It looks huge but it just moves the test and test utilities in separate modules for cleaner conditional compilation.